### PR TITLE
Update auto-tag.yml

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -10,7 +10,7 @@ name: auto-tag
 
 on:
   workflow_run:
-    workflows: ["Run tests"]
+    workflows: ["test"]
     branches: [main]
     types:
       - completed


### PR DESCRIPTION
Fixed a typo in the workflow config that was using the old name of the test workflow, causing this workflow to not be triggered 