### PR TITLE
Check outputs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = src

--- a/README.md
+++ b/README.md
@@ -54,14 +54,17 @@ To use `enforce-notebook-run-order` as a standalone script, simply run
 it with the path to the notebook(s) you want to check:
 
 ``` {.sourceCode .bash}
-enforce-notebook-run-order my_notebook.ipynb my_other_notebook.ipynb
+nbcheck my_notebook.ipynb my_other_notebook.ipynb
 ```
 
 Or point it to a directory to check all notebooks in that directory:
 
 ``` {.sourceCode .bash}
-enforce-notebook-run-order my_notebooks/
+nbcheck my_notebooks/
 ```
+
+You can also use the full `enforce-notebook-run-order` command, but the
+`nbcheck` command is provided as a convenience.
 
 ### pre-commit hook
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ nbcheck my_notebooks/
 You can also use the full `enforce-notebook-run-order` command, but the
 `nbcheck` command is provided as a convenience.
 
+For information on the command line interface, please refer to the [CLI
+documentation](module_enforce_notebook_run_order.html#command-line-interface).
+
 ### pre-commit hook
 
 To use `enforce_notebook_run_order` as a pre-commit hook, add the

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -37,13 +37,16 @@ notebook(s) you want to check:
 
 .. code-block:: bash
 
-    enforce-notebook-run-order my_notebook.ipynb my_other_notebook.ipynb
+    nbcheck my_notebook.ipynb my_other_notebook.ipynb
 
 Or point it to a directory to check all notebooks in that directory:
 
 .. code-block:: bash
 
-    enforce-notebook-run-order my_notebooks/
+    nbcheck my_notebooks/
+
+You can also use the full ``enforce-notebook-run-order`` command, but the ``nbcheck`` command is
+provided as a convenience.
 
 pre-commit hook
 ^^^^^^^^^^^^^^^

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -48,6 +48,8 @@ Or point it to a directory to check all notebooks in that directory:
 You can also use the full ``enforce-notebook-run-order`` command, but the ``nbcheck`` command is
 provided as a convenience.
 
+For information on the command line interface, please refer to the `CLI documentation <module_enforce_notebook_run_order.html#command-line-interface>`__.
+
 pre-commit hook
 ^^^^^^^^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,4 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 enforce-notebook-run-order = "enforce_notebook_run_order:cli"
+nbcheck = "enforce_notebook_run_order:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "enforce-notebook-run-order"
-version = "1.0.0"
+version = "1.1.0"
 description = ""
 authors = ["Chris Hacker <49451910+christopher-hacker@users.noreply.github.com>"]
 license = "MIT"

--- a/src/enforce_notebook_run_order.py
+++ b/src/enforce_notebook_run_order.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 from typing import List
 import click
+import temp_notebook
 
 
 class NotebookCodeCellNotRunError(Exception):
@@ -75,11 +76,16 @@ def check_single_notebook(notebook_path: str):
         notebook_data = json.load(notebook_file)
     try:
         check_notebook_run_order(notebook_data)
-    except (NotebookCodeCellNotRunError, NotebookRunOrderError) as error:
+        with temp_notebook.TempNotebook(notebook_data) as temp_nb:
+            temp_nb.check_notebook()
+    except (
+        NotebookCodeCellNotRunError,
+        NotebookRunOrderError,
+        temp_notebook.InvalidNotebookJsonError,
+        temp_notebook.CellOutputMismatchError,
+    ) as error:
         raise InvalidNotebookRunError(
-            f"Notebook {notebook_path} was not run in order.\n\n"
-            # append the error message from the check_notebook_run_order function
-            f"{error}\n\n"
+            f"Notebook {notebook_path} was not run in order.\n\n{error}\n\n"
         ) from error
     print(f"Notebook {notebook_path} was run correctly.")
 

--- a/src/enforce_notebook_run_order.py
+++ b/src/enforce_notebook_run_order.py
@@ -4,6 +4,7 @@ import json
 import os
 import pathlib
 from typing import List
+import warnings
 import click
 import temp_notebook
 
@@ -129,6 +130,14 @@ def cli(paths: List[str] = None, no_run: bool = False):
     Checks the run order of notebooks in the specified paths,
     or the entire repo if no paths are specified
     """
+    if no_run:
+        warnings.warn(
+            "The --no-run option will not catch all problems with notebooks. "
+            "It is possible that the checks will pass, but the notebook was still run "
+            "out of order. It is highly recommended to move any long-running code to a separate "
+            "task that runs separately from the notebook."
+        )
+
     if paths:
         for path in paths:
             process_path(path, no_run)

--- a/src/enforce_notebook_run_order.py
+++ b/src/enforce_notebook_run_order.py
@@ -81,6 +81,7 @@ def check_single_notebook(path: str):
             # append the error message from the check_notebook_run_order function
             f"{error}\n\n"
         ) from error
+    print(f"Notebook {notebook_path} was run correctly.")
 
 
 def process_path(path: str):

--- a/src/enforce_notebook_run_order.py
+++ b/src/enforce_notebook_run_order.py
@@ -68,9 +68,9 @@ def check_notebook_run_order(notebook_data: dict) -> None:
             previous_cell_number = current_cell_number
 
 
-def check_single_notebook(path: str):
+def check_single_notebook(notebook_path: str):
     """Check a single notebook."""
-    notebook_path = pathlib.Path(path)
+    notebook_path = pathlib.Path(notebook_path)
     with open(notebook_path, "r", encoding="UTF-8") as notebook_file:
         notebook_data = json.load(notebook_file)
     try:

--- a/src/temp_notebook.py
+++ b/src/temp_notebook.py
@@ -1,0 +1,72 @@
+"""creates and runs a temporary notebook to verify outputs"""
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+class InvalidNotebookJsonError(Exception):
+    """
+    raised when a notebook fails to run because the provided json is not a valid notebook
+    """
+
+
+class TempNotebook:
+    """creates and runs a temporary notebook to verify outputs"""
+
+    def __init__(self, notebook_data: dict):
+        """
+        Args:
+            notebook_path (Union[str, pathlib.Path]): Path to the notebook file.
+        """
+        self.notebook_data = notebook_data
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.notebook_path = self.temp_dir / "temp_notebook.ipynb"
+        self.create_temp_file()
+
+    def create_temp_file(self):
+        """creates a temporary notebook file with the given notebook data"""
+
+        with open(self.notebook_path, "w", encoding="UTF-8") as notebook_file:
+            json.dump(self.notebook_data, notebook_file)
+
+    def run(self):
+        """runs the temporary notebook"""
+        try:
+            subprocess.run(
+                [
+                    "jupyter",
+                    "nbconvert",
+                    "--to",
+                    "notebook",
+                    "--execute",
+                    self.notebook_path,
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as error:
+            raise InvalidNotebookJsonError(
+                f"Notebook {self.notebook_path} failed to run.\n\n"
+                f"Error message: {error}\n\n"
+            ) from error
+
+        # get the json data from the saved notebook
+        # file will be at filename.nbconvert.ipynb
+        output_file_path = self.notebook_path.with_suffix(".nbconvert.ipynb")
+        with open(output_file_path, "r", encoding="UTF-8") as output_file:
+            output_data = json.load(output_file)
+        return output_data
+
+    def __del__(self):
+        """deletes the temporary directory"""
+        shutil.rmtree(self.temp_dir)
+
+    def __enter__(self):
+        """returns the path to the temporary notebook"""
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        """deletes the temporary directory"""
+        del self

--- a/test/test_enforce_notebook_run_order.py
+++ b/test/test_enforce_notebook_run_order.py
@@ -208,9 +208,10 @@ def test_cli_no_paths_searches_entire_dir(mocker):
 def test_cli_no_run_option(mocker):
     """
     Tests that process_path is called with the correct run option
-    when the --no-run option is specified.
+    when the --no-run option is specified, and a warning was was printed
     """
     mock_process_path = mocker.patch("enforce_notebook_run_order.process_path")
+    mock_warning = mocker.patch("enforce_notebook_run_order.warnings.warn")
 
     runner = CliRunner()
     result = runner.invoke(
@@ -227,3 +228,4 @@ def test_cli_no_run_option(mocker):
     )
 
     assert result.exit_code == 0
+    assert mock_warning.call_count == 1

--- a/test/test_enforce_notebook_run_order.py
+++ b/test/test_enforce_notebook_run_order.py
@@ -200,6 +200,30 @@ def test_cli_no_paths_searches_entire_dir(mocker):
     result = runner.invoke(enforce_notebook_run_order.cli)
 
     # The process_path function should be called once, with the current directory as its argument
-    mock_process_path.assert_called_once_with(".")
+    mock_process_path.assert_called_once_with(".", False)
+
+    assert result.exit_code == 0
+
+
+def test_cli_no_run_option(mocker):
+    """
+    Tests that process_path is called with the correct run option
+    when the --no-run option is specified.
+    """
+    mock_process_path = mocker.patch("enforce_notebook_run_order.process_path")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        enforce_notebook_run_order.cli,
+        [
+            "test/test_data/enforce_notebook_run_order_valid",
+            "--no-run",
+        ],
+    )
+
+    # The process_path function should be called once, with the current directory as its argument
+    mock_process_path.assert_called_once_with(
+        "test/test_data/enforce_notebook_run_order_valid", True
+    )
 
     assert result.exit_code == 0

--- a/test/test_temp_notebook.py
+++ b/test/test_temp_notebook.py
@@ -16,13 +16,19 @@ def valid_notebook_data():
                 "cell_type": "code",
                 "execution_count": 1,
                 "metadata": {},
-                "outputs": [],
+                "outputs": [
+                    {
+                        "name": "stdout",
+                        "output_type": "stream",
+                        "text": ["hello world\n"],
+                    }
+                ],
                 "source": ['print("hello world")'],
             }
         ],
         "metadata": {
             "kernelspec": {
-                "display_name": "Python 3",
+                "display_name": ".venv",
                 "language": "python",
                 "name": "python3",
             },
@@ -33,11 +39,12 @@ def valid_notebook_data():
                 "name": "python",
                 "nbconvert_exporter": "python",
                 "pygments_lexer": "ipython3",
-                "version": "3.8.5",
+                "version": "3.8.10",
             },
+            "orig_nbformat": 4,
         },
         "nbformat": 4,
-        "nbformat_minor": 4,
+        "nbformat_minor": 2,
     }
 
 

--- a/test/test_temp_notebook.py
+++ b/test/test_temp_notebook.py
@@ -1,0 +1,66 @@
+"""tests the temp notebook module"""
+
+import os
+import pytest
+import temp_notebook
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def valid_notebook_data():
+    """returns the complete json of a jupyter notebook with 1 cell"""
+    return {
+        "cells": [
+            {
+                "cell_type": "code",
+                "execution_count": 1,
+                "metadata": {},
+                "outputs": [],
+                "source": ['print("hello world")'],
+            }
+        ],
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            },
+            "language_info": {
+                "codemirror_mode": {"name": "ipython", "version": 3},
+                "file_extension": ".py",
+                "mimetype": "text/x-python",
+                "name": "python",
+                "nbconvert_exporter": "python",
+                "pygments_lexer": "ipython3",
+                "version": "3.8.5",
+            },
+        },
+        "nbformat": 4,
+        "nbformat_minor": 4,
+    }
+
+
+@pytest.fixture
+def invalid_notebook_data():
+    """returns json that is not a valid jupyter notebook"""
+    return {"not_a_notebook": True}
+
+
+def test_create_temp_file(valid_notebook_data):
+    """tests that the temp notebook creates a temporary file"""
+    with temp_notebook.TempNotebook(valid_notebook_data) as temp_notebook_obj:
+        assert os.path.exists(temp_notebook_obj.notebook_path)
+
+
+def test_run_valid_json(valid_notebook_data):
+    """tests that the temp notebook runs with valid json"""
+    with temp_notebook.TempNotebook(valid_notebook_data) as temp_notebook_obj:
+        temp_notebook_obj.run()
+
+
+def test_run_invalid_json(invalid_notebook_data):
+    """tests that the temp notebook raises an exception with invalid json"""
+    with temp_notebook.TempNotebook(invalid_notebook_data) as temp_notebook_obj:
+        with pytest.raises(temp_notebook.InvalidNotebookJsonError):
+            temp_notebook_obj.run()

--- a/test/test_temp_notebook.py
+++ b/test/test_temp_notebook.py
@@ -71,3 +71,9 @@ def test_run_invalid_json(invalid_notebook_data):
     with temp_notebook.TempNotebook(invalid_notebook_data) as temp_notebook_obj:
         with pytest.raises(temp_notebook.InvalidNotebookJsonError):
             temp_notebook_obj.run()
+
+
+def test_check_notebook_valid(valid_notebook_data):
+    """tests that the temp notebook passes with valid json"""
+    with temp_notebook.TempNotebook(valid_notebook_data) as temp_notebook_obj:
+        temp_notebook_obj.check_notebook()

--- a/test/test_temp_notebook.py
+++ b/test/test_temp_notebook.py
@@ -54,6 +54,53 @@ def invalid_notebook_data():
     return {"not_a_notebook": True}
 
 
+@pytest.fixture
+def output_mismatch_data():
+    """
+    returns the json of a notebook whose cell output does not match
+    the expected output
+    """
+    return {
+        "cells": [
+            {
+                "cell_type": "code",
+                "execution_count": 1,
+                "metadata": {},
+                "outputs": [],
+                "source": ["var_1 = 2\n"],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": 2,
+                "metadata": {},
+                "outputs": [
+                    {"name": "stdout", "output_type": "stream", "text": ["1\n"]}
+                ],
+                "source": ["print(var_1)\n"],
+            },
+        ],
+        "metadata": {
+            "kernelspec": {
+                "display_name": ".venv",
+                "language": "python",
+                "name": "python3",
+            },
+            "language_info": {
+                "codemirror_mode": {"name": "ipython", "version": 3},
+                "file_extension": ".py",
+                "mimetype": "text/x-python",
+                "name": "python",
+                "nbconvert_exporter": "python",
+                "pygments_lexer": "ipython3",
+                "version": "3.8.10",
+            },
+            "orig_nbformat": 4,
+        },
+        "nbformat": 4,
+        "nbformat_minor": 2,
+    }
+
+
 def test_create_temp_file(valid_notebook_data):
     """tests that the temp notebook creates a temporary file"""
     with temp_notebook.TempNotebook(valid_notebook_data) as temp_notebook_obj:
@@ -77,3 +124,10 @@ def test_check_notebook_valid(valid_notebook_data):
     """tests that the temp notebook passes with valid json"""
     with temp_notebook.TempNotebook(valid_notebook_data) as temp_notebook_obj:
         temp_notebook_obj.check_notebook()
+
+
+def test_check_notebook_invalid(output_mismatch_data):
+    """tests that the temp notebook fails with invalid json"""
+    with temp_notebook.TempNotebook(output_mismatch_data) as temp_notebook_obj:
+        with pytest.raises(temp_notebook.CellOutputMismatchError):
+            temp_notebook_obj.check_notebook()


### PR DESCRIPTION
This branch adds a significant new feature: verification of cell outputs. 

While the initial checks were sufficient to catch the most obvious errors, it's still possible that a notebook can still be run out of order, yet still have an `execution_count` that appears to be sequential. This can happen if a notebook was run in order, then restarted, had some changes made, then _partially_ run. 

The only way to check this is to run the entire notebook, so `enforce-notebook-run-order` now runs the entire notebook and compares the outputs to the original outputs and fails if they don't match. 